### PR TITLE
nbbpm.compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodebb-plugin-emailer-yandex",
   "version": "0.2.5",
   "nbbpm": {
-    "compatibility": "^0.7.1 || ^0.8.0"
+    "compatibility": "^0.7.1 || ^0.8.0 || ^0.9.0"
   },
   "description": "NodeBB plugin to send emails via Yandex SMTP service",
   "keywords": [


### PR DESCRIPTION
Noticed this package was updated, but `nbbpm.compatbility` flag was not :smile: 
